### PR TITLE
Adjust for renaming of README to README.md

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -45,7 +45,7 @@ SourceRepository := rec(
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
 PackageWWWHome  := "https://gap-packages.github.io/sgpviz",
-README_URL      := Concatenation( ~.PackageWWWHome, "/README" ),
+README_URL      := Concatenation( ~.PackageWWWHome, "/README.md" ),
 PackageInfoURL  := Concatenation( ~.PackageWWWHome, "/PackageInfo.g" ),
 ArchiveURL      := Concatenation( ~.SourceRepository.URL,
                                  "/releases/download/v", ~.Version,

--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ If you  have found important features missing or if there is a bug, I would appr
 Contents
 --------
 With this version you should have obtained the following files and directories:
+
 | File/directory | Description |
 |:-----|:------|
-|README |   this file|
+|README.md|   this file|
 |EXAMPLES|	some examples|
 |CHANGES|	changelog|
 |LICENSE|	Licensing information|


### PR DESCRIPTION
The README_URL in the PackageInfo.g file was invalid (recent
versions of ReleaseTools will catch this and prevent a release until
it is fixed).

Also update the filename inside the README itself, and insert
a space before the markdown table, so that it renders correctly in
with more MarkDown converters