### PR TITLE
Switch to two argument version of ReadPackage

### DIFF
--- a/init.g
+++ b/init.g
@@ -10,14 +10,14 @@
 ##
 #R  Read the actual code.
 ##
-ReadPackage( "sgpviz/gap/basicsViz.gd" );
-ReadPackage( "sgpviz/gap/grahamblocks.gd" );
-ReadPackage( "sgpviz/gap/drawdclasses.gd" );
-ReadPackage( "sgpviz/gap/semigroupfactorization.gd" );
-ReadPackage( "sgpviz/gap/schutzenberger-graphs.gd" );
-ReadPackage( "sgpviz/gap/sgpviz-display.gd" );
-ReadPackage( "sgpviz/gap/xautomaton.gd" );
-ReadPackage( "sgpviz/gap/xsemigroup.gd" );
-ReadPackage( "sgpviz/gap/sv_utils.gd");
+ReadPackage( "sgpviz", "gap/basicsViz.gd" );
+ReadPackage( "sgpviz", "gap/grahamblocks.gd" );
+ReadPackage( "sgpviz", "gap/drawdclasses.gd" );
+ReadPackage( "sgpviz", "gap/semigroupfactorization.gd" );
+ReadPackage( "sgpviz", "gap/schutzenberger-graphs.gd" );
+ReadPackage( "sgpviz", "gap/sgpviz-display.gd" );
+ReadPackage( "sgpviz", "gap/xautomaton.gd" );
+ReadPackage( "sgpviz", "gap/xsemigroup.gd" );
+ReadPackage( "sgpviz", "gap/sv_utils.gd");
 
 #E  init.g  . . . . . . . . . . . . . . . . . . . . . . . . . . .  ends here

--- a/read.g
+++ b/read.g
@@ -10,17 +10,17 @@
 ##
 DeclareInfoClass("InfoViz");
 DeclareInfoClass("InfoSgpViz");
-#ReadPackage( "sgpviz/gap/infolevelsgpviz" );
-ReadPackage( "sgpviz/gap/splash_from_Viz.g" );
+#ReadPackage( "sgpviz", "gap/infolevelsgpviz" );
+ReadPackage( "sgpviz", "gap/splash_from_Viz.g" );
 
-ReadPackage( "sgpviz/gap/basicsViz.gi" );
-ReadPackage( "sgpviz/gap/grahamblocks.gi" );
-ReadPackage( "sgpviz/gap/drawdclasses.gi" );
-ReadPackage( "sgpviz/gap/semigroupfactorization.gi" );
-ReadPackage( "sgpviz/gap/schutzenberger-graphs.gi" );
-ReadPackage( "sgpviz/gap/sgpviz-display.gi" );
-ReadPackage( "sgpviz/gap/xautomaton.gi" );
-ReadPackage( "sgpviz/gap/xsemigroup.gi" );
-ReadPackage( "sgpviz/gap/sv_utils.gi");
+ReadPackage( "sgpviz", "gap/basicsViz.gi" );
+ReadPackage( "sgpviz", "gap/grahamblocks.gi" );
+ReadPackage( "sgpviz", "gap/drawdclasses.gi" );
+ReadPackage( "sgpviz", "gap/semigroupfactorization.gi" );
+ReadPackage( "sgpviz", "gap/schutzenberger-graphs.gi" );
+ReadPackage( "sgpviz", "gap/sgpviz-display.gi" );
+ReadPackage( "sgpviz", "gap/xautomaton.gi" );
+ReadPackage( "sgpviz", "gap/xsemigroup.gi" );
+ReadPackage( "sgpviz", "gap/sv_utils.gi");
 
 #E  read.g  . . . . . . . . . . . . . . . . . . . . . . . . . . .  ends here


### PR DESCRIPTION
The one argument form is not recommended, as it just has to split
the string into two anyway, and the input looks like a path, but
it isn't really, as the first part is a pacakge name, not a
directory name...
